### PR TITLE
Update to pytorch-0.4

### DIFF
--- a/wavenet_modules.py
+++ b/wavenet_modules.py
@@ -53,7 +53,7 @@ class DilatedQueue:
             self.data = Variable(dtype(num_channels, max_length).zero_())
 
     def enqueue(self, input):
-        self.data[:, self.in_pos] = input
+        self.data[:, self.in_pos] = input[:, 0]
         self.in_pos = (self.in_pos + 1) % self.max_length
 
     def dequeue(self, num_deq=1, dilation=1):

--- a/wavenet_training.py
+++ b/wavenet_training.py
@@ -69,7 +69,7 @@ class WavenetTrainer:
                 loss = F.cross_entropy(output.squeeze(), target.squeeze())
                 self.optimizer.zero_grad()
                 loss.backward()
-                loss = loss.data[0]
+                loss = loss.item()
 
                 if self.clip is not None:
                     torch.nn.utils.clip_grad_norm(self.model.parameters(), self.clip)
@@ -100,11 +100,11 @@ class WavenetTrainer:
 
             output = self.model(x)
             loss = F.cross_entropy(output.squeeze(), target.squeeze())
-            total_loss += loss.data[0]
+            total_loss += loss.item()
 
             predictions = torch.max(output, 1)[1].view(-1)
             correct_pred = torch.eq(target, predictions)
-            accurate_classifications += torch.sum(correct_pred).data[0]
+            accurate_classifications += torch.sum(correct_pred).item()
         # print("validate model with " + str(len(self.dataloader.dataset)) + " samples")
         # print("average loss: ", total_loss / len(self.dataloader))
         avg_loss = total_loss / len(self.dataloader)


### PR DESCRIPTION
Using pytorch-0.4.1 to run this code, I encountered several problems. I'm creating this pull request to propose a solution to these issues. 
One blocking issue is related with `generate_fast()` that raise a `RuntimeError: the number of sizes provided (1) must be greater or equal to the number of dimensions in the tensor (2)`
I also modified to code to avoid warnings: 
- nn.functional.tanh and sigmoid are deprecated in favor of torch.tanh and sigmoid
- scalar should be accessed with `item()`
- `Variable` are deprecated in favor of `requires_grad` args

Unfortunately, I could not verify that these modifications are functional on pytorch < 0.4. I'll try to install pytorch 0.3 on another system and see if it is backward compatible.

Thank you very much for this nice code, I was a huge help to understand WaveNet! I hope I could contribute to this project.